### PR TITLE
Cache improvements

### DIFF
--- a/jumpapp/classes/Cache.php
+++ b/jumpapp/classes/Cache.php
@@ -108,6 +108,12 @@ class Cache {
         if ($this->config->parse_bool($this->config->get('cachebypass'))) {
             $this->storage = new Caching\Storages\DevNullStorage();
         } else {
+            if (!is_dir($this->config->get('cachedir').'/application')) {
+                mkdir($this->config->get('cachedir').'/application', 0755, true);
+            }
+            if (!is_dir($this->config->get('cachedir').'/favicon')) {
+                mkdir($this->config->get('cachedir').'/favicon', 0755, true);
+            }
             $this->storage = new Caching\Storages\FileStorage($this->config->get('cachedir').'/application');
         }
     }

--- a/jumpapp/classes/Site.php
+++ b/jumpapp/classes/Site.php
@@ -68,6 +68,9 @@ class Site {
             if ($this->iconname === null) {
                 // Go get the favicon, if there isnt one then use the default icon.
                 $favicon = new \Favicon\Favicon();
+                if (!$this->config->parse_bool($this->config->get('cachebypass'))) {
+                    $favicon->cache(['dir' => $this->config->get('cachedir').'/favicon']);
+                }
                 $rawimage = $favicon->get($this->url, \Favicon\FaviconDLType::RAW_IMAGE);
             } else {
                 // If the icon name has a file extension the n try to retrieve it locally, otherwise


### PR DESCRIPTION
I would say creating cache dirs is good idea. (however this is just my suggestion)
Use case? Storing it in tmpfs - the path will no exist on boot ending in app throwing exception.

Also move `arthurhoaro/favicon` cache dir from directory in vendor dir to the app's cache dir.
