### PR TITLE
Add key binds to Jump for cycling through tabs and sites.

### DIFF
--- a/jumpapp/assets/css/src/_sites.scss
+++ b/jumpapp/assets/css/src/_sites.scss
@@ -25,7 +25,7 @@ $unknown-color: #ccc;
 			position: relative;
 			overflow: hidden;
 
-			&:hover {
+			&:hover, &.active {
 				background-color: #fff;
 				box-shadow: 0 1px 5px rgba(0,0,0,.6);
 			}
@@ -125,7 +125,7 @@ $unknown-color: #ccc;
 			padding: 12px;
 			border-radius: 6px;
 
-			&:hover {
+			&:hover, &.active {
 				background-color: #ffffff15;
 				transition: background-color .1s;
 			}

--- a/jumpapp/assets/css/src/_tags.scss
+++ b/jumpapp/assets/css/src/_tags.scss
@@ -70,7 +70,7 @@
                 margin-left: 1px;
                 border-radius: 4px;
 
-                &:hover {
+                &:hover, &.active {
                     background-color: #f3f3f3;
                     transition: background-color .1s;
                 }

--- a/jumpapp/assets/js/src/classes/KeyBinds.js
+++ b/jumpapp/assets/js/src/classes/KeyBinds.js
@@ -1,5 +1,5 @@
 /**
- * Add key binds to JUMP, allowing the user to navigate
+ * Add key binds to Jump, allowing the user to navigate
  * through tags and sites using their keyboards. When the
  * user presses "T", the tag dropdown is opened and the
  * arrow keys can be used to cycle through the tags. When
@@ -28,7 +28,7 @@ export default class KeyBinds {
 
         document.addEventListener("keyup", (e) => {
             this.keys.set(e.key, false);
-        })
+        });
     }
 
     /**
@@ -77,9 +77,9 @@ export default class KeyBinds {
         if (this.keys.get("ArrowUp") || this.keys.get("ArrowDown") || this.keys.get("ArrowLeft") || this.keys.get("ArrowRight")) {
             // Determine whether tags or sites should be cycled through.
             if (document.getElementById("tags").classList.contains("enable")) {
-                this.navigate_elements('#tags', this.keys.get("ArrowDown") || this.keys.get("ArrowRight"));
+                this.navigate_elements("#tags", this.keys.get("ArrowDown") || this.keys.get("ArrowRight"));
             } else {
-                this.navigate_elements('ul.sites', this.keys.get("ArrowDown") || this.keys.get("ArrowRight"));
+                this.navigate_elements("ul.sites", this.keys.get("ArrowDown") || this.keys.get("ArrowRight"));
             }
             return;
         }
@@ -96,8 +96,8 @@ export default class KeyBinds {
         }
 
         // The ESCAPE key will deselect any active tag or site and close the tags list.
-        if (this.keys.get('Escape')) {
-            document.querySelectorAll('a.active').forEach(a => a.classList.remove('active'));
+        if (this.keys.get("Escape")) {
+            document.querySelectorAll("a.active").forEach(a => a.classList.remove("active"));
             document.getElementById("tags").classList.remove("enable");
         }
     }
@@ -116,7 +116,7 @@ export default class KeyBinds {
 
         // Function that returns the default element that should be activated if none is found by
         // other means.
-        const getDefault = () => document.querySelector(`${containerSelector} li:${forward ? 'first' : 'last'}-of-type a`);
+        const getDefault = () => document.querySelector(`${containerSelector} li:${forward ? "first" : "last"}-of-type a`);
 
         if (activeEl) {
             activeEl.classList.toggle("active");

--- a/jumpapp/assets/js/src/classes/KeyBinds.js
+++ b/jumpapp/assets/js/src/classes/KeyBinds.js
@@ -69,7 +69,24 @@ export default class KeyBinds {
     parse_navigation() {
         // The T key is bound to opening and closing the tags list.
         if (this.keys.get("t")) {
-            document.getElementById("tags").classList.toggle("enable");
+            const tagsEl = document.getElementById("tags");
+            tagsEl.classList.toggle("enable");
+
+            // Mark the active tag so the user is aware where navigation begins.
+            if (tagsEl.classList.contains("enable") && tagsEl.querySelector('a.active') === null) {
+                // Try and read the tag from the URL. If that fails, select the first one.
+                const tag = document.location.pathname.split('/').filter(x => !!x).pop();
+
+                if (tag) {
+                    tagsEl.querySelectorAll("a").forEach(a => {
+                        if (a.textContent === tag) {
+                            a.classList.add("active");
+                        }
+                    });
+                } else {
+                    tagsEl.querySelector("a").classList.add("active");
+                }
+            }
             return;
         }
 

--- a/jumpapp/assets/js/src/classes/KeyBinds.js
+++ b/jumpapp/assets/js/src/classes/KeyBinds.js
@@ -1,0 +1,125 @@
+/**
+ * Add key binds to JUMP, allowing the user to navigate
+ * through tags and sites using their keyboards. When the
+ * user presses "T", the tag dropdown is opened and the
+ * arrow keys can be used to cycle through the tags. When
+ * the tag list is closed, the sites will be navigated
+ * with the arrow keys instead. Pressing ENTER will open
+ * the selected tag or site, pressing ESCAPE will deselect
+ * both active tag and site. The user can also open a site
+ * by pressing CTRL + number. When a site is found at the
+ * pressed number, it will be opened. Numbers start at 1
+ * and end at 0 (ten).
+ */
+export default class KeyBinds {
+    constructor() {
+        this.keys = new Map();
+        this.numericKeys = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"];
+    }
+
+    /**
+     * Initialise the key binds by adding event listeners.
+     */
+    init() {
+        document.addEventListener("keydown", (e) => {
+            this.keys.set(e.key, true);
+            this.process();
+        });
+
+        document.addEventListener("keyup", (e) => {
+            this.keys.set(e.key, false);
+        })
+    }
+
+    /**
+     * Determine whether to directly open a site or navigate the tags or sites.
+     */
+    process() {
+        if (this.keys.get("Control")) {
+            this.activate_site();
+        } else {
+            this.parse_navigation();
+        }
+    }
+
+    /**
+     * Activate the site for the number that was pressed on the keyboard.
+     */
+    activate_site() {
+        // Determine the number that was pressed.
+        const site = this.numericKeys.find((n) => this.keys.get(n) === true);
+
+        if (site) {
+            // Convert 0 to 10, so ten shortcuts can be offered with 1 being the first.
+            const num = site === "0" ? "10" : site;
+
+            // Find the site for the number. When none is found, the result will be null.
+            const anchor = document.querySelector(`ul.sites li:nth-child(${num}) a`);
+
+            // Trigger the anchor of the site, if any.
+            if (anchor) {
+                anchor.click();
+            }
+        }
+    }
+
+    /**
+     * Parse the active key to determine how to navigate.
+     */
+    parse_navigation() {
+        // The T key is bound to opening and closing the tags list.
+        if (this.keys.get("t")) {
+            document.getElementById("tags").classList.toggle("enable");
+            return;
+        }
+
+        // The arrow keys will cycle through tags or sites.
+        if (this.keys.get("ArrowUp") || this.keys.get("ArrowDown") || this.keys.get("ArrowLeft") || this.keys.get("ArrowRight")) {
+            // Determine whether tags or sites should be cycled through.
+            if (document.getElementById("tags").classList.contains("enable")) {
+                this.navigate_elements('#tags', this.keys.get("ArrowDown") || this.keys.get("ArrowRight"));
+            } else {
+                this.navigate_elements('ul.sites', this.keys.get("ArrowDown") || this.keys.get("ArrowRight"));
+            }
+            return;
+        }
+
+        // The ENTER key will activate a selected tag or site.
+        if (this.keys.get("Enter")) {
+            // Determine whether tags or sites should be triggered.
+            if (document.getElementById("tags").classList.contains("enable")) {
+                document.querySelector("#tags a.active").click();
+            } else {
+                document.querySelector("ul.sites a.active").click();
+            }
+            return;
+        }
+    
+        // The ESCAPE key will deselect any active tag or site.
+        if (this.keys.get('Escape')) {
+            document.querySelectorAll('a.active').forEach(a => a.classList.remove('active'));
+        }
+    }
+
+    /**
+     * Navigate through tags or sites.
+     * @param containerSelector {string} The CSS selector for the container in which the anchors can be found.
+     * @param forward {boolean} Whether we are cycling forward through the list of anchors or not.
+     */
+    navigate_elements(containerSelector, forward) {
+        let newEl;
+
+        // Find the currently active anchor. When found, the next link will be determined, otherwise
+        // the first or last, based on the value of "forward", will be selected.
+        const activeEl = document.querySelector(`${containerSelector} a.active`);
+
+        if (activeEl) {
+            activeEl.classList.toggle("active");
+            newEl = (forward ? activeEl.parentElement.nextElementSibling : activeEl.parentElement.previousElementSibling)?.querySelector("a");
+        } else {
+            newEl = document.querySelector(`${containerSelector} li:${forward ? 'first' : 'last'}-of-type a`);
+        }
+
+        newEl?.classList.toggle("active");
+    }
+}

--- a/jumpapp/assets/js/src/classes/KeyBinds.js
+++ b/jumpapp/assets/js/src/classes/KeyBinds.js
@@ -88,16 +88,17 @@ export default class KeyBinds {
         if (this.keys.get("Enter")) {
             // Determine whether tags or sites should be triggered.
             if (document.getElementById("tags").classList.contains("enable")) {
-                document.querySelector("#tags a.active").click();
+                document.querySelector("#tags a.active")?.click();
             } else {
-                document.querySelector("ul.sites a.active").click();
+                document.querySelector("ul.sites a.active")?.click();
             }
             return;
         }
-    
-        // The ESCAPE key will deselect any active tag or site.
+
+        // The ESCAPE key will deselect any active tag or site and close the tags list.
         if (this.keys.get('Escape')) {
             document.querySelectorAll('a.active').forEach(a => a.classList.remove('active'));
+            document.getElementById("tags").classList.remove("enable");
         }
     }
 
@@ -113,11 +114,15 @@ export default class KeyBinds {
         // the first or last, based on the value of "forward", will be selected.
         const activeEl = document.querySelector(`${containerSelector} a.active`);
 
+        // Function that returns the default element that should be activated if none is found by
+        // other means.
+        const getDefault = () => document.querySelector(`${containerSelector} li:${forward ? 'first' : 'last'}-of-type a`);
+
         if (activeEl) {
             activeEl.classList.toggle("active");
-            newEl = (forward ? activeEl.parentElement.nextElementSibling : activeEl.parentElement.previousElementSibling)?.querySelector("a");
+            newEl = (forward ? activeEl.parentElement.nextElementSibling : activeEl.parentElement.previousElementSibling)?.querySelector("a") || getDefault();
         } else {
-            newEl = document.querySelector(`${containerSelector} li:${forward ? 'first' : 'last'}-of-type a`);
+            newEl = getDefault();
         }
 
         newEl?.classList.toggle("active");

--- a/jumpapp/assets/js/src/classes/Main.js
+++ b/jumpapp/assets/js/src/classes/Main.js
@@ -14,6 +14,7 @@ import Clock from './Clock';
 import EventEmitter from 'eventemitter3';
 import Fuse from 'fuse.js';
 import Greeting from './Greeting';
+import KeyBinds from './KeyBinds';
 import SearchSuggestions from './SearchSuggestions';
 import Weather from './Weather';
 
@@ -47,6 +48,7 @@ export default class Main {
         this.eventemitter = new EventEmitter();
         this.clock = new Clock(this.eventemitter, !!JUMP.ampmclock, !JUMP.owmapikey);
         this.weather = new Weather(this.eventemitter);
+        this.keyBinds = new KeyBinds();
 
         if (this.showsearchbuttonelm) {
             this.searchclosebuttonelm = this.showsearchbuttonelm.querySelector('.close');
@@ -245,6 +247,8 @@ export default class Main {
                 }
             });
         }
+
+        this.keyBinds.init();
     }
 
     search_close() {


### PR DESCRIPTION
This PR adds key binds to Jump:

- Pressing `T` will open or close the tags menu.
- Pressing `↑`, `↓`, `←` or `→` will cycle through the tags when the tags menu is open.
- When the tags menu is closed, the arrows will cycle through the sites.
- `↑` and `←` will both cycle back, whereas `↓` and `→` will cycle forward.
- Pressing `Enter` will activate the selected tag or site.
- Pressing `Escape` will clear selections.
- Pressing `Ctrl` followed by a number will open the site at that position. For example, `Ctrl` + `1` will open the site on the first tile, `Ctrl` + `2` the site on the second tile, and so on. The first ten tiles can be opened this way.