### PR TITLE
Update Matomo URL

### DIFF
--- a/jumpapp/sites/sites.json
+++ b/jumpapp/sites/sites.json
@@ -34,7 +34,7 @@
         },
         {
             "name": "Matomo",
-            "url" : "https://matomo.org/pagedoesnotexist",
+            "url" : "https://matomo.org/",
             "nofollow": false,
             "tags": ["home", "stuff"]
         },


### PR DESCRIPTION
The Matomo URL resulted in a 404 error. Updated with an actual URL to improve UX.